### PR TITLE
Api client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1242,6 +1242,10 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@transcenders/api-client": {
+      "resolved": "packages/api-client",
+      "link": true
+    },
     "node_modules/@transcenders/contracts": {
       "resolved": "packages/contracts",
       "link": true
@@ -6290,6 +6294,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/api-client": {
+      "name": "@transcenders/api-client",
+      "version": "1.0.0",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.33",
+        "@transcenders/contracts": "^1.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.8.3"
       }
     },
     "packages/contracts": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "dev:all": "concurrently --names 'BACKEND,FRONTEND' --prefix-colors 'blue,green' 'npm run dev --workspace=user-service' 'npm run dev --workspace=web'",
     "dev:backend": "npm run dev --workspace=user-service",
     "dev:frontend": "npm run dev --workspace=web",
-    "test": "tsx scripts/tests.ts"
+    "test": "tsx scripts/tests.ts",
+    "api-client-test": "tsx scripts/api-client-test.ts"
   },
   "devDependencies": {
     "concurrently": "^9.1.2",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@transcenders/api-client",
+  "version": "1.0.0",
+  "description": "fetch wrapper for all our microservice calls with validation, timeouts, and error handling.",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@transcenders/contracts": "^1.0.0",
+    "@sinclair/typebox": "^0.34.33"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3"
+  }
+}

--- a/packages/api-client/src/api/ApiClient.ts
+++ b/packages/api-client/src/api/ApiClient.ts
@@ -1,0 +1,80 @@
+import { Value } from '@sinclair/typebox/value';
+import { ApiResponse } from '@transcenders/contracts';
+import { UserApiService } from '../services/user.service';
+import { ApiCallOptions } from '../types/client.options';
+
+export class ApiClient {
+  /**
+   * Enhanced main call function
+   */
+  static async call(url: string, options: ApiCallOptions = {}): Promise<ApiResponse> {
+    const { method = 'GET', body, headers = {}, timeout = 5000, expectedDataSchema } = options;
+
+    try {
+      const requestInit: RequestInit = {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+          ...headers,
+        },
+        signal: AbortSignal.timeout(timeout),
+      };
+
+      if (body && method !== 'GET') {
+        requestInit.body = typeof body === 'string' ? body : JSON.stringify(body);
+      }
+
+      console.log(`API Call: ${method} ${url}`);
+      const response = await fetch(url, requestInit);
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => 'Unknown error');
+        return this.errorResponse(`HTTP ${response.status}: ${response.statusText} - ${errorText}`);
+      }
+
+      const contentType = response.headers.get('content-type');
+      if (!contentType?.includes('application/json')) {
+        return this.errorResponse('Response is not JSON');
+      }
+
+      const data = await response.json();
+
+      // Validate response format
+      if (!Value.Check(ApiResponse, data)) {
+        console.error('Invalid response format:', data);
+        return this.errorResponse('Invalid response format from service');
+      }
+
+      // Validate expected data schema if provided
+      if (data.success && expectedDataSchema) {
+        if (!Value.Check(expectedDataSchema, data.data)) {
+          console.error('Data schema validation failed:', data.data);
+          return this.errorResponse('Response data does not match expected schema');
+        }
+      }
+
+      return data;
+    } catch (error) {
+      console.error('API call failed:', error);
+
+      if (error instanceof Error) {
+        if (error.name === 'AbortError') {
+          return this.errorResponse(`Request timeout after ${timeout}ms`);
+        }
+        return this.errorResponse(error.message);
+      }
+
+      return this.errorResponse('Network error');
+    }
+  }
+
+  private static errorResponse(error: string): ApiResponse {
+    return {
+      success: false,
+      operation: 'api-call',
+      error,
+    };
+  }
+
+  static user = UserApiService;
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,0 +1,1 @@
+export { ApiClient } from './api/ApiClient';

--- a/packages/api-client/src/services/auth.service.ts
+++ b/packages/api-client/src/services/auth.service.ts
@@ -1,0 +1,29 @@
+import { ApiResponse, AUTH_ROUTES, SERVICE_URLS } from '@transcenders/contracts';
+import { ApiClient } from '../api/ApiClient';
+import { ApiCallOptions } from '../types/client.options';
+
+export class AuthApiService {
+  /**
+   * Internal method to call the auth service
+   */
+  private static async callAUthService(
+    endpoint: string,
+    options: ApiCallOptions = {},
+  ): Promise<ApiResponse> {
+    const url = `${SERVICE_URLS.AUTH}${endpoint}`;
+    return ApiClient.call(url, options);
+  }
+
+  /**
+   * Gets a list of users based on optional query parameters
+   * #TODO register() input/request type
+   */
+
+  static async register(username: string, password: string) {
+    const endpoint = `${AUTH_ROUTES.AUTH.replace(':username', username).replace(
+      ':password',
+      password,
+    )}`;
+    return this.callAUthService(endpoint);
+  }
+}

--- a/packages/api-client/src/services/user.service.ts
+++ b/packages/api-client/src/services/user.service.ts
@@ -24,6 +24,8 @@ export class UserApiService {
     return ApiClient.call(url, options);
   }
 
+  // #TODO schema validate all the data
+
   /**
    * Gets a list of users based on optional query parameters
    */

--- a/packages/api-client/src/services/user.service.ts
+++ b/packages/api-client/src/services/user.service.ts
@@ -1,0 +1,134 @@
+import {
+  ApiResponse,
+  CreateUserRequest,
+  FRIENDSHIP_ROUTES,
+  GetUserRequest,
+  GetUsersQuery,
+  SERVICE_URLS,
+  toQueryString,
+  USER_ROUTES,
+  UserSchema,
+} from '@transcenders/contracts';
+import { ApiClient } from '../api/ApiClient';
+import { ApiCallOptions } from '../types/client.options';
+
+export class UserApiService {
+  /**
+   * Internal method to call the user service
+   */
+  private static async callUserService(
+    endpoint: string,
+    options: ApiCallOptions = {},
+  ): Promise<ApiResponse> {
+    const url = `${SERVICE_URLS.USER}${endpoint}`;
+    return ApiClient.call(url, options);
+  }
+
+  /**
+   * Gets a list of users based on optional query parameters
+   */
+  static async getUsers(query?: GetUsersQuery) {
+    const queryString = query ? toQueryString(query) : '';
+    return this.callUserService(`${USER_ROUTES.USERS}${queryString}`);
+  }
+
+  /**
+   * Creates a new user
+   */
+  static async createUser(userData: CreateUserRequest) {
+    return this.callUserService(USER_ROUTES.USERS, {
+      method: 'POST',
+      body: userData,
+    });
+  }
+
+  /**
+   * Gets a user by their ID
+   */
+  static async getUserById(id: number) {
+    return this.callUserService(USER_ROUTES.USER_BY_ID.replace(':id', id.toString()));
+  }
+
+  /**
+   * Updates a user's information
+   */
+  static async updateUser(id: number, userData: object) {
+    return this.callUserService(USER_ROUTES.USER_BY_ID.replace(':id', id.toString()), {
+      method: 'PATCH',
+      body: userData,
+    });
+  }
+
+  /**
+   * Deletes a user
+   */
+  static async deleteUser(id: number) {
+    return this.callUserService(USER_ROUTES.USER_BY_ID.replace(':id', id.toString()), {
+      method: 'DELETE',
+    });
+  }
+
+  /**
+   * Checks if a user with the given identifier exists
+   */
+  static async checkUserExists(identifier: string) {
+    return this.callUserService(USER_ROUTES.USER_EXISTS.replace(':identifier', identifier));
+  }
+
+  /**
+   * Gets a user based on exact match parameters
+   */
+  static async getUserExact(query: GetUserRequest) {
+    const queryString = `?${new URLSearchParams(query).toString()}`;
+    return this.callUserService(`${USER_ROUTES.USERS_EXACT}${queryString}`, {
+      expectedDataSchema: UserSchema,
+    });
+  }
+
+  // Friendship methods
+  static async getFriends(userId: number) {
+    return this.callUserService(
+      FRIENDSHIP_ROUTES.USER_FRIENDSHIPS.replace(':id', userId.toString()),
+    );
+  }
+
+  static async sendFriendRequest(userId: number, recipientId: number) {
+    return this.callUserService(
+      FRIENDSHIP_ROUTES.SEND_FRIEND_REQUEST.replace(':id', userId.toString()).replace(
+        ':recipientId',
+        recipientId.toString(),
+      ),
+      { method: 'POST' },
+    );
+  }
+
+  static async acceptFriendRequest(userId: number, requestId: number) {
+    return this.callUserService(
+      FRIENDSHIP_ROUTES.FRIEND_REQUEST.replace(':id', userId.toString()).replace(
+        ':requestId',
+        requestId.toString(),
+      ),
+      { method: 'PUT' },
+    );
+  }
+
+  static async declineFriendRequest(userId: number, requestId: number) {
+    return this.callUserService(
+      FRIENDSHIP_ROUTES.FRIEND_REQUEST.replace(':id', userId.toString()).replace(
+        ':requestId',
+        requestId.toString(),
+      ),
+      { method: 'DELETE' },
+    );
+  }
+
+  static async removeFriend(userId: number, friendId: number) {
+    return this.callUserService(
+      FRIENDSHIP_ROUTES.FRIENDSHIP.replace(':id', userId.toString()).replace(
+        ':friendId',
+        friendId.toString(),
+      ),
+      { method: 'DELETE' },
+    );
+  }
+}

--- a/packages/api-client/src/types/client.options.ts
+++ b/packages/api-client/src/types/client.options.ts
@@ -1,0 +1,15 @@
+import { TSchema } from '@sinclair/typebox';
+
+export interface ServiceConfig {
+  baseUrl: string;
+  timeout?: number;
+  headers?: Record<string, string>;
+}
+
+export interface ApiCallOptions {
+  method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  body?: string | object;
+  headers?: Record<string, string>;
+  timeout?: number;
+  expectedDataSchema?: TSchema;
+}

--- a/packages/api-client/tsconfig.json
+++ b/packages/api-client/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2,3 +2,4 @@ export * from './errors';
 export * from './interfaces';
 export * from './routes';
 export * from './user.schemas';
+export * from './utils/query';

--- a/packages/contracts/src/routes.ts
+++ b/packages/contracts/src/routes.ts
@@ -1,6 +1,6 @@
 export const SERVICE_URLS = {
-  USER: process.env.USER_SERVICE_URL ?? 'http://user-service:3001',
-  AUTH: process.env.AUTH_SERVICE_URL ?? 'http://user-service:3002',
+  USER: process.env.USER_SERVICE_URL ?? 'http://localhost:3001',
+  AUTH: process.env.AUTH_SERVICE_URL ?? 'http://localhost:3002',
 };
 
 export const USER_ROUTES = {

--- a/packages/contracts/src/routes.ts
+++ b/packages/contracts/src/routes.ts
@@ -1,3 +1,8 @@
+export const SERVICE_URLS = {
+  USER: process.env.USER_SERVICE_URL ?? 'http://user-service:3001',
+  AUTH: process.env.AUTH_SERVICE_URL ?? 'http://user-service:3002',
+};
+
 export const USER_ROUTES = {
   // GET /users - List users (with optional query params: ?search=, ?limit=, ?offset=)
   // POST /users - Create new user
@@ -37,4 +42,9 @@ export const FRIENDSHIP_ROUTES = {
 
   // GET /friendships/:id1/:id2 - Check if friendship exists between two users
   FRIENDSHIP_EXISTS: '/friendships/:id1/:id2',
+} as const;
+
+export const AUTH_ROUTES = {
+  // GET /auth - auth inital idk #TODO fix and add more
+  AUTH: '/auth/:username/:password',
 } as const;

--- a/packages/contracts/src/user.schemas.ts
+++ b/packages/contracts/src/user.schemas.ts
@@ -27,7 +27,7 @@ const FriendRequestStateField = Type.Union([Type.Literal('pending'), Type.Litera
 /**
  * ENTITY SCHEMAS
  */
-const UserSchema = Type.Object({
+export const UserSchema = Type.Object({
   id: UserIdField,
   username: UsernameField,
   email: EmailField,

--- a/packages/contracts/src/user.schemas.ts
+++ b/packages/contracts/src/user.schemas.ts
@@ -14,7 +14,8 @@ import { Static, Type } from '@sinclair/typebox';
  */
 const UserIdField = Type.Number();
 const UsernameField = Type.String({ minLength: 3, maxLength: 20 });
-const EmailField = Type.String({ format: 'email' });
+//TODO fix email validation schema
+const EmailField = Type.String();
 const DisplayNameField = Type.String({ maxLength: 50 });
 const AvatarField = Type.String();
 const LangField = Type.String({ maxLength: 2 });
@@ -38,6 +39,9 @@ export const UserSchema = Type.Object({
   updated_at: TimestampField,
 });
 export type User = Static<typeof UserSchema>;
+
+export const UsersArraySchema = Type.Array(UserSchema);
+export type UsersArray = Static<typeof UsersArraySchema>;
 
 const userModifiableFields = Type.Object({
   username: UsernameField,

--- a/packages/contracts/src/utils/query.ts
+++ b/packages/contracts/src/utils/query.ts
@@ -1,0 +1,9 @@
+export function toQueryString(
+  params: Record<string, string | number | boolean | undefined | null>,
+): string {
+  const entries = Object.entries(params)
+    .filter(([, v]) => v !== undefined && v !== null)
+    .map(([k, v]) => [k, String(v)]);
+
+  return entries.length ? `?${new URLSearchParams(entries)}` : '';
+}

--- a/scripts/api-client-test.ts
+++ b/scripts/api-client-test.ts
@@ -1,0 +1,50 @@
+import { ApiClient } from '@transcenders/api-client';
+import { CreateUserRequest, User, USER_ROUTES } from '@transcenders/contracts';
+
+const API_BASE = 'http://localhost:3001';
+
+async function testDirectCall() {
+  const response = await ApiClient.call(`${API_BASE}${USER_ROUTES.USERS}`);
+  console.log('direct call:', response.success ? 'ok' : response.error);
+}
+
+async function testUserService() {
+  const response = await ApiClient.user.getUsers();
+
+  console.log(
+    'user service:',
+    response.success ? `got ${(response.data as User[]).length ?? 0} users` : response.error,
+  );
+}
+
+async function testCrud() {
+  const testUser: CreateUserRequest = {
+    username: 'test_user_123',
+    email: 'test@example.com',
+    display_name: 'Test User',
+  };
+
+  // create
+  const created = await ApiClient.user.createUser(testUser);
+  if (!created.success) {
+    console.log('create failed:', created.error);
+    return;
+  }
+  const userId = (created.data as User).id;
+  console.log('created user:', userId);
+
+  // update
+  const updated = await ApiClient.user.updateUser(userId, { display_name: 'Updated User' });
+  console.log('update:', updated.success ? 'ok' : updated.error);
+
+  // cleanup
+  await ApiClient.user.deleteUser(userId);
+}
+
+async function main() {
+  await testDirectCall();
+  await testUserService();
+  await testCrud();
+}
+
+main();


### PR DESCRIPTION
Uh... I just like refactoring and DevOps too much, I think I'm going to seperate another package that I currently have in the contracts package, but it makes no sense there 😛

it will be called @transcenders/api-client located at /packages/api-client

its a fetch wrapper for all our microservice calls with validation, timeouts, and error handling.

**Core function:**
```typescript
static async call(url: string, options: ApiCallOptions = {}): Promise<ApiResponseType>

interface ApiCallOptions {
  method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
  body?: string | object;
  headers?: Record<string, string>;
  timeout?: number;
  expectedDataSchema?: TSchema;  // TypeBox validation!
}
```

**Service-level abstraction:**
```typescript
static async callUserService(endpoint: string, options: ApiCallOptions = {}) {
  const url = `${SERVICE_URLS.USER}${endpoint}`;
  return this.call(url, options);
}
```

**Ready-to-use methods:**
```typescript
static async createUser(userData: CreateUserRequest) {
  return this.callUserService(USER_ROUTES.USERS, {
    method: 'POST',
    body: userData,
  });
}
```


**Usage:** 
```bash
# first add it as a dependency to your package.json
cd your-branch
npm add @transcenders/api-client
#need to rebuild containers if using dockerized env after new package installs I should probably DevOps fix that part also, but for now:
make rebuild
#or
make local #if running local dev
```
```typescript

import { ApiClient } from `@trancenders/api-client';
await ApiClient.createUser({ username: 'alicia', email: 'alicia@42.fr' })
```

Later we'll just swap `SERVICE_URLS` to point to our gateway instead of direct services.

**Tests:**
Also added some tests that showcase the usage of the api-client

you can run it by doing `npm run api-client-test`
and check out how it works at `/scripts/api-client.test.ts`


**Package Updates:** 
Managing this package will probably be everyone's job in the future!

Need a list of tournament games? Instead of doing fetch in your code directly, add it to the package using the same pattern so everyone can use it.

```bash
# 1. Create feature branch
git checkout -b feature/add-tournament-api

# 2. Add method to api-client
static async getTournaments() {
  return this.callTournamentService(TOURNAMENT_ROUTES.TOURNAMENTS);
}

# 3. Test locally
make

# 4. Commit and push
git add packages/
git commit -m "feat: add tournament API methods"
git push origin feature/add-tournament-api

# 5. Create PR
# Review → Merge → Everyone gets the new methods!
```

**Result:** Everyone can now use `await ApiClient.getTournaments()` instead of writing their own fetch logic.