### PR TITLE
Feature/user stats api for score service

### DIFF
--- a/packages/contracts/src/routes.ts
+++ b/packages/contracts/src/routes.ts
@@ -64,9 +64,11 @@ export const AUTH_ROUTES = {
 
 export const SCORE_ROUTES = {
   // GET /scores - List scores (with optional query params: ?search=, ?limit=, ?offset=)
-  SCORES: '/score/',
+  SCORES: '/score',
   // POST /score - Create a new score entry after a game
-  SCORE: '/score/',
-  // GET /score/:id - Get a users game history and statistics
+  SCORE: '/score',
+  // GET /score/:id/matches - Get a user's match history
   SCORES_BY_ID: '/score/:id',
+  // GET /score/:id/stats - Get a user's statistics
+  STATS_BY_ID: '/score/:id/stats',
 } as const;

--- a/packages/contracts/src/score.schemas.ts
+++ b/packages/contracts/src/score.schemas.ts
@@ -1,40 +1,18 @@
 import { Static, Type } from '@sinclair/typebox';
-export const WinnerIdField = Type.Number();
-export const LoserIdField = Type.Number();
-export const WinnerScoreField = Type.Number();
-export const LoserScoreField = Type.Number();
-export const TournamentLevelField = Type.Number();
-export const GameDurationField = Type.Number();
-export const GameStartTimeField = Type.Number();
-export const GameEndTimeField = Type.Number();
-export const ScoresByIdField = Type.Number();
-export const TotalGamesField = Type.Number();
-export const TotalWinsField = Type.Number();
-export const TotalWinPercentageField = Type.Number();
-export const RegularGamesField = Type.Number();
-export const RegularGameWinsField = Type.Number();
-export const RegularGameWinPercentageField = Type.Number();
-export const TournamentGamesField = Type.Number();
-export const TournamentGameWinsField = Type.Number();
-export const TournamentGameWinPercentageField = Type.Number();
-export const TournamentWinsField = Type.Number();
-export const TotalScoreField = Type.Number();
-export const AverageScoreField = Type.Number();
-export const TotalDurationField = Type.Number();
-export const AverageDurationField = Type.Number();
+import { TimestampField, UserIdField } from './user.schemas';
 
 /**
  * ENTITY SCHEMAS
  */
 export const ScoreSchema = Type.Object({
-  winner_id: WinnerIdField,
-  loser_id: LoserIdField,
-  winner_score: WinnerScoreField,
-  loser_score: LoserScoreField,
-  tournament_level: TournamentLevelField,
-  game_duration: GameDurationField,
-  game_start: GameStartTimeField,
-  game_end: GameEndTimeField,
+  winner_id: UserIdField,
+  loser_id: UserIdField,
+  winner_score: Type.Number(),
+  loser_score: Type.Number(),
+  tournament_level: Type.Number(),
+  game_duration: Type.Number(),
+  game_start: TimestampField,
+  game_end: TimestampField,
 });
 export type Score = Static<typeof ScoreSchema>;
 
@@ -42,20 +20,20 @@ export const ScoresArraySchema = Type.Array(ScoreSchema);
 export type ScoresArray = Static<typeof ScoresArraySchema>;
 
 export const StatsSchema = Type.Object({
-  total_games: TotalGamesField,
-  total_wins: TotalWinsField,
-  total_win_percentage: TotalWinPercentageField,
-  regular_games: RegularGamesField,
-  regular_game_wins: RegularGameWinsField,
-  regular_game_win_percentage: RegularGameWinPercentageField,
-  tournament_games: TournamentGamesField,
-  tourament_game_wins: TournamentWinsField,
-  tournament_game_win_percentage: TournamentGameWinPercentageField,
-  tournament_wins: TournamentWinsField,
-  total_score: TotalScoreField,
-  average_score: AverageScoreField,
-  total_duration: TotalDurationField,
-  average_duration: AverageDurationField
+  total_games: Type.Number(),
+  total_wins: Type.Number(),
+  total_win_percentage: Type.Number(),
+  regular_games: Type.Number(),
+  regular_game_wins: Type.Number(),
+  regular_game_win_percentage: Type.Number(),
+  tournament_games: Type.Number(),
+  tourament_game_wins: Type.Number(),
+  tournament_game_win_percentage: Type.Number(),
+  tournament_wins: Type.Number(),
+  total_score: Type.Number(),
+  average_score: Type.Number(),
+  total_duration: Type.Number(),
+  average_duration: Type.Number(),
 });
 export type Stats = Static<typeof StatsSchema>;
 
@@ -64,14 +42,14 @@ export type Stats = Static<typeof StatsSchema>;
  */
 export const createScoreSchema = {
   body: Type.Object({
-    winner_id: WinnerIdField,
-    loser_id: LoserIdField,
-    winner_score: WinnerScoreField,
-    loser_score: LoserScoreField,
-    tournament_level: TournamentLevelField,
-    game_duration: GameDurationField,
-    game_start: GameStartTimeField,
-    game_end: GameEndTimeField,
+    winner_id: UserIdField,
+    loser_id: UserIdField,
+    winner_score: Type.Number(),
+    loser_score: Type.Number(),
+    tournament_level: Type.Number(),
+    game_duration: Type.Number(),
+    game_start: TimestampField,
+    game_end: TimestampField,
   }),
 };
 export type CreateScoreRequest = Static<typeof createScoreSchema.body>;
@@ -101,14 +79,14 @@ export type GetScoreRequest = Static<typeof getScoreSchema.querystring>;
 
 export const scoresByIdSchema = {
   params: Type.Object({
-    id: ScoresByIdField,
+    id: UserIdField,
   }),
 };
 export type ScoresByIdRequest = Static<typeof scoresByIdSchema.params>;
 
 export const statsByIdSchema = {
   params: Type.Object({
-    id: ScoresByIdField,
+    id: UserIdField,
   }),
 };
 export type StatsByIdRequest = Static<typeof statsByIdSchema.params>;

--- a/packages/contracts/src/score.schemas.ts
+++ b/packages/contracts/src/score.schemas.ts
@@ -8,6 +8,20 @@ export const GameDurationField = Type.Number();
 export const GameStartTimeField = Type.Number();
 export const GameEndTimeField = Type.Number();
 export const ScoresByIdField = Type.Number();
+export const TotalGamesField = Type.Number();
+export const TotalWinsField = Type.Number();
+export const TotalWinPercentageField = Type.Number();
+export const RegularGamesField = Type.Number();
+export const RegularGameWinsField = Type.Number();
+export const RegularGameWinPercentageField = Type.Number();
+export const TournamentGamesField = Type.Number();
+export const TournamentGameWinsField = Type.Number();
+export const TournamentGameWinPercentageField = Type.Number();
+export const TournamentWinsField = Type.Number();
+export const TotalScoreField = Type.Number();
+export const AverageScoreField = Type.Number();
+export const TotalDurationField = Type.Number();
+export const AverageDurationField = Type.Number();
 
 /**
  * ENTITY SCHEMAS
@@ -26,6 +40,24 @@ export type Score = Static<typeof ScoreSchema>;
 
 export const ScoresArraySchema = Type.Array(ScoreSchema);
 export type ScoresArray = Static<typeof ScoresArraySchema>;
+
+export const StatsSchema = Type.Object({
+  total_games: TotalGamesField,
+  total_wins: TotalWinsField,
+  total_win_percentage: TotalWinPercentageField,
+  regular_games: RegularGamesField,
+  regular_game_wins: RegularGameWinsField,
+  regular_game_win_percentage: RegularGameWinPercentageField,
+  tournament_games: TournamentGamesField,
+  tourament_game_wins: TournamentWinsField,
+  tournament_game_win_percentage: TournamentGameWinPercentageField,
+  tournament_wins: TournamentWinsField,
+  total_score: TotalScoreField,
+  average_score: AverageScoreField,
+  total_duration: TotalDurationField,
+  average_duration: AverageDurationField
+});
+export type Stats = Static<typeof StatsSchema>;
 
 /**
  * REQUEST SCHEMAS
@@ -69,7 +101,14 @@ export type GetScoreRequest = Static<typeof getScoreSchema.querystring>;
 
 export const scoresByIdSchema = {
   params: Type.Object({
-	id: ScoresByIdField,
+    id: ScoresByIdField,
   }),
 };
 export type ScoresByIdRequest = Static<typeof scoresByIdSchema.params>;
+
+export const statsByIdSchema = {
+  params: Type.Object({
+    id: ScoresByIdField,
+  }),
+};
+export type StatsByIdRequest = Static<typeof statsByIdSchema.params>;

--- a/services/score-service/src/controllers/ScoreController.ts
+++ b/services/score-service/src/controllers/ScoreController.ts
@@ -2,6 +2,7 @@ import {
   GetScoresQuery,
   CreateScoreRequest,
   ScoresByIdRequest,
+  StatsByIdRequest,
   ResponseHelper,
 } from '@transcenders/contracts';
 import { FastifyReply, FastifyRequest } from 'fastify';
@@ -28,6 +29,14 @@ export class ScoreController {
     const userId = id;
 
     const result = await ScoreService.getScoresById(userId);
+    return ResponseHelper.handleDatabaseResult(reply, result);
+  }
+
+  static async getStatsById(request: FastifyRequest, reply: FastifyReply) {
+    const { id } = request.params as StatsByIdRequest;
+    const userId = id;
+
+    const result = await ScoreService.getStatsById(userId);
     return ResponseHelper.handleDatabaseResult(reply, result);
   }
 }

--- a/services/score-service/src/routes/score.routes.ts
+++ b/services/score-service/src/routes/score.routes.ts
@@ -4,6 +4,7 @@ import {
   standardApiResponses,
   SCORE_ROUTES,
   scoresByIdSchema,
+  statsByIdSchema,
 } from '@transcenders/contracts';
 import { FastifyInstance } from 'fastify';
 import { ScoreController } from '../controllers/ScoreController';
@@ -17,7 +18,7 @@ export async function registerScoreRoutes(app: FastifyInstance) {
     SCORE_ROUTES.SCORES,
     {
       schema: {
-        description: 'List scores (with optional query params: ?search=, ?limit=, ?offset=)',
+        description: 'List scores (with optional query params: ?id=, ?limit=, ?offset=)',
         tags: ['Score'],
         querystring: getScoresSchema.querystring,
         response: standardApiResponses,
@@ -50,5 +51,18 @@ export async function registerScoreRoutes(app: FastifyInstance) {
       },
     },
     ScoreController.getScoresById,
+  );
+
+  app.get(
+    SCORE_ROUTES.STATS_BY_ID,
+    {
+      schema: {
+        description: 'Get user stats by user ID',
+        tags: ['Score'],
+        params: statsByIdSchema.params,
+        response: standardApiResponses,
+      },
+    },
+    ScoreController.getStatsById,
   );
 }

--- a/services/score-service/src/services/ScoreService.ts
+++ b/services/score-service/src/services/ScoreService.ts
@@ -46,7 +46,7 @@ export class ScoreService {
 
     const score = await this.getScoreByIdLogic(database, result.lastID);
     if (!score) {
-      throw new Error('User created but not found');
+      throw new Error('Score created but not found');
     }
 
     return score;
@@ -56,7 +56,7 @@ export class ScoreService {
 
   static async getAllScores(query: GetScoresQuery): Promise<DatabaseResult<Score[]>> {
     const db = await getDB();
-    return DatabaseHelper.executeQuery<Score[]>('get all users', db, async (database) => {
+    return DatabaseHelper.executeQuery<Score[]>('get all scores', db, async (database) => {
       const sql = SQL`SELECT * FROM scores`;
       if (query.search) {
         const searchTerm = `%${query.search}%`;
@@ -80,7 +80,7 @@ export class ScoreService {
 
   static async getScoresById(id: number): Promise<DatabaseResult<Score[]>> {
     const db = await getDB();
-    return DatabaseHelper.executeQuery<Score[]>('get user', db, async (database) => {
+    return DatabaseHelper.executeQuery<Score[]>('get scores by id', db, async (database) => {
       const scores = await this.getScoresByIdLogic(database, id);
       if (!scores) {
         const error = new Error(`no games found for user id '${id}'`);

--- a/services/score-service/src/services/ScoreService.ts
+++ b/services/score-service/src/services/ScoreService.ts
@@ -5,6 +5,7 @@ import {
   DB_ERROR_CODES,
   GetScoresQuery,
   Score,
+  Stats,
 } from '@transcenders/contracts';
 import SQL from 'sql-template-strings';
 import { Database } from 'sqlite';
@@ -22,13 +23,77 @@ export class ScoreService {
     return score ? (score as Score) : null;
   }
 
-  private static async getScoresByIdLogic(database: Database, id: number): Promise<Score[] | null> {
+  private static async getScoresByIdLogic(database: Database, id: number): Promise<Score[]> {
     const sql = SQL`
       SELECT * FROM scores WHERE winner_id = ${id} OR loser_id = ${id}
     `;
     sql.append(SQL` ORDER BY game_end DESC`);
     const userScores = await database.all(sql.text, sql.values);
     return userScores as Score[];
+  }
+
+  private static async calculateStats(scores: Score[], id: number): Promise<Stats> {
+    let total_games = 0;
+    let total_wins = 0;
+    let total_win_percentage = 0;
+    let regular_games = 0;
+    let regular_game_wins = 0;
+    let regular_game_win_percentage = 0;
+    let tournament_games = 0;
+    let tourament_game_wins = 0;
+    let tournament_game_win_percentage = 0;
+    let tournament_wins = 0;
+    let total_score = 0;
+    let total_duration = 0;
+    let average_score = 0;
+    let average_duration = 0;
+
+    for (const score of scores) {
+      total_games++;
+      total_duration += score.game_duration;
+      if (score.tournament_level === 0)
+        regular_games++;
+      else
+        tournament_games++;
+      if (id === score.winner_id) {
+          total_wins++;
+          total_score += score.winner_score;
+          if (score.tournament_level === 0) {
+            regular_game_wins++;
+          }
+          else {
+            if (score.tournament_level === 1) {
+              tournament_wins++;
+            }
+            tourament_game_wins++;
+          }
+      } else {
+        total_score += score.loser_score;
+      }
+    }
+
+    if (total_games > 0) {
+      total_win_percentage = total_wins / total_games * 100;
+      if (regular_games > 0) {
+        regular_game_win_percentage = regular_game_wins / regular_games * 100;
+      }
+      if (tournament_games > 0) {
+        tournament_game_win_percentage = tourament_game_wins / tournament_games * 100;
+      }
+      average_score = total_score / total_games;
+      average_duration = total_duration / total_games;
+    }
+
+    return {total_games, total_wins, total_win_percentage, 
+      regular_games, regular_game_wins, regular_game_win_percentage, 
+      tournament_games, tourament_game_wins, tournament_game_win_percentage, tournament_wins, 
+      total_score, average_score, total_duration, average_duration } as Stats;
+  }
+
+  private static async getStatsByIdLogic(database: Database, id: number): Promise<Stats> {
+    const scores = await this.getScoresByIdLogic(database, id);
+    const stats = await this.calculateStats(scores, id);
+    return stats;
   }
 
   private static async createScoreLogic(database: Database, scoreData: CreateScoreRequest, ): Promise<Score> {
@@ -78,6 +143,7 @@ export class ScoreService {
     });
   }
 
+  // TODO Add query string support for limit and offset to implement pagination support
   static async getScoresById(id: number): Promise<DatabaseResult<Score[]>> {
     const db = await getDB();
     return DatabaseHelper.executeQuery<Score[]>('get scores by id', db, async (database) => {
@@ -91,4 +157,16 @@ export class ScoreService {
     });
   }
 
+  static async getStatsById(id: number): Promise<DatabaseResult<Stats>> {
+    const db = await getDB();
+    return DatabaseHelper.executeQuery<Stats>('get stats by id', db, async (database) => {
+      const stats = await this.getStatsByIdLogic(database, id);
+      if (!stats) {
+        const error = new Error(`no games found for user id '${id}'`);
+        (error as any).code = DB_ERROR_CODES.RECORD_NOT_FOUND;
+        throw error;
+      }
+      return stats as Stats;
+    });
+  }
 }


### PR DESCRIPTION
Adds an API and related schema to fetch a user's stats using the user's id. Fixes score service bugs and removes some redundant exports.

Example of the Stats object and the fields it contains:
```JSON
{
    "total_games": 6,
    "total_wins": 6,
    "total_win_percentage": 100,
    "regular_games": 4,
    "regular_game_wins": 4,
    "regular_game_win_percentage": 100,
    "tournament_games": 2,
    "tourament_game_wins": 2,
    "tournament_game_win_percentage": 100,
    "tournament_wins": 1,
    "total_score": 66,
    "average_score": 11,
    "total_duration": 0,
    "average_duration": 0
  }
```