### PR TITLE
Implements global authentication state management

### DIFF
--- a/packages/api-client/src/api/ApiClient.ts
+++ b/packages/api-client/src/api/ApiClient.ts
@@ -4,18 +4,28 @@ import { ScoreApiClient } from '../services/score.api.js';
 import { UserApiClient } from '../services/user.api.js';
 import { ApiCallOptions } from '../types/client.options.js';
 
+let authHeader: string | undefined;
 export class ApiClient {
+  // Set or clear the Authorization header globally
+  static setAuthToken(token?: string) {
+    authHeader = token ? `Bearer ${token}` : undefined;
+  }
+  static getAuthToken(): string | undefined {
+    return authHeader;
+  }
   /**
    * Simple HTTP client for helpers
    */
   static async call(url: string, options: ApiCallOptions = {}): Promise<ApiResponseType> {
     const { method = 'GET', body, headers = {}, timeout = 20000 } = options;
 
+    const mergedHeaders: Record<string, string> = {
+      ...(authHeader ? { Authorization: authHeader } : {}),
+      ...headers,
+    };
     const requestInit: RequestInit = {
       method,
-      headers: {
-        ...headers,
-      },
+      headers: mergedHeaders,
       //#TODO temporary disabled timeout for debugging
       // signal: AbortSignal.timeout(timeout),
     };
@@ -26,7 +36,7 @@ export class ApiClient {
       } else {
         requestInit.headers = {
           'Content-Type': 'application/json',
-          ...requestInit.headers,
+          ...(requestInit.headers as Record<string, string>),
         };
         requestInit.body = typeof body === 'string' ? body : JSON.stringify(body);
       }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,3 +1,4 @@
+import AuthBootstrap from './components/AuthBootstrap';
 import Header from './layout/Header';
 import MainContainer from './layout/MainContainer';
 // import Footer from './layout/Footer'
@@ -5,10 +6,12 @@ import MainContainer from './layout/MainContainer';
 const App = () => {
   return (
     <div className="w-screen h-screen overflow-hidden">
-      <div className="flex flex-col h-full">
-        <Header />
-        <MainContainer />
-      </div>
+      <AuthBootstrap>
+        <div className="flex flex-col h-full">
+          <Header />
+          <MainContainer />
+        </div>
+      </AuthBootstrap>
     </div>
   );
 };

--- a/web/src/components/AuthBootstrap.tsx
+++ b/web/src/components/AuthBootstrap.tsx
@@ -1,0 +1,50 @@
+import { ApiClient } from '@transcenders/api-client';
+import { decodeToken } from '@transcenders/contracts';
+import { useEffect, useState, type ReactNode } from 'react';
+import { useAuth } from '../hooks/useAuth';
+import { useUser } from '../hooks/useUser';
+import { getTokens } from '../utils/authTokens';
+
+export default function AuthBootstrap({ children }: { children: ReactNode }) {
+  const [ready, setReady] = useState(false);
+  const { setAccessToken, clearTokens } = useAuth();
+  const { setUser } = useUser();
+
+  useEffect(() => {
+    async function autoLogin() {
+      const { accessToken, refreshToken } = getTokens();
+      if (accessToken) {
+        try {
+          setAccessToken(accessToken);
+          const { userId } = decodeToken(accessToken);
+          const user = await ApiClient.user.getUserById(userId);
+          setUser(user);
+          setReady(true);
+          return;
+        } catch {
+          // fall through to refresh if available
+        }
+      }
+
+      if (refreshToken) {
+        try {
+          const tokens = await ApiClient.auth.refreshToken(refreshToken);
+          setAccessToken(tokens.accessToken);
+          const { userId } = decodeToken(tokens.accessToken);
+          const user = await ApiClient.user.getUserById(userId);
+          setUser(user);
+          setReady(true);
+          return;
+        } catch {
+          clearTokens();
+        }
+      }
+      setReady(true);
+    }
+
+    autoLogin();
+  }, [setAccessToken, clearTokens, setUser]);
+
+  if (!ready) return null;
+  return <>{children}</>;
+}

--- a/web/src/components/AuthBootstrap.tsx
+++ b/web/src/components/AuthBootstrap.tsx
@@ -7,7 +7,7 @@ import { getTokens } from '../utils/authTokens';
 
 export default function AuthBootstrap({ children }: { children: ReactNode }) {
   const [ready, setReady] = useState(false);
-  const { setAccessToken, clearTokens } = useAuth();
+  const { setAccessToken, clearTokens, setTokens } = useAuth();
   const { setUser } = useUser();
 
   useEffect(() => {
@@ -29,7 +29,7 @@ export default function AuthBootstrap({ children }: { children: ReactNode }) {
       if (refreshToken) {
         try {
           const tokens = await ApiClient.auth.refreshToken(refreshToken);
-          setAccessToken(tokens.accessToken);
+          setTokens(tokens);
           const { userId } = decodeToken(tokens.accessToken);
           const user = await ApiClient.user.getUserById(userId);
           setUser(user);
@@ -43,7 +43,7 @@ export default function AuthBootstrap({ children }: { children: ReactNode }) {
     }
 
     autoLogin();
-  }, [setAccessToken, clearTokens, setUser]);
+  }, [setAccessToken, clearTokens, setUser, setTokens]);
 
   if (!ready) return null;
   return <>{children}</>;

--- a/web/src/contexts/AuthContext.ts
+++ b/web/src/contexts/AuthContext.ts
@@ -1,0 +1,12 @@
+import { AuthData } from '@transcenders/contracts';
+import { createContext } from 'react';
+
+interface AuthContextType {
+  accessToken?: string;
+  refreshToken?: string;
+  setTokens: (tokens: AuthData) => void;
+  setAccessToken: (accessToken: string) => void;
+  clearTokens: () => void;
+}
+
+export const AuthContext = createContext<AuthContextType | undefined>(undefined);

--- a/web/src/contexts/AuthContextProvider.tsx
+++ b/web/src/contexts/AuthContextProvider.tsx
@@ -1,0 +1,42 @@
+import { ApiClient } from '@transcenders/api-client';
+import type { AuthData } from '@transcenders/contracts';
+import type { ReactNode } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { clearAllTokens, getTokens, saveAccessToken, saveTokens } from '../utils/authTokens';
+import { AuthContext } from './AuthContext';
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [{ accessToken, refreshToken }, setState] = useState(() => getTokens());
+
+  useEffect(() => {
+    ApiClient.setAuthToken(accessToken);
+  }, [accessToken]);
+
+  const setTokens = (tokens: AuthData) => {
+    saveTokens(tokens);
+    setState({
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+    });
+    ApiClient.setAuthToken(tokens.accessToken);
+  };
+
+  const setAccessToken = (token: string) => {
+    saveAccessToken(token);
+    setState((prev) => ({ ...prev, accessToken: token }));
+    ApiClient.setAuthToken(token);
+  };
+
+  const clearTokens = () => {
+    clearAllTokens();
+    setState({ accessToken: undefined, refreshToken: undefined });
+    ApiClient.setAuthToken();
+  };
+
+  const value = useMemo(
+    () => ({ accessToken, refreshToken, setTokens, setAccessToken, clearTokens }),
+    [accessToken, refreshToken],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}

--- a/web/src/hooks/useAuth.ts
+++ b/web/src/hooks/useAuth.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { AuthContext } from '../contexts/AuthContext';
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/web/src/hooks/useAuthLogin.ts
+++ b/web/src/hooks/useAuthLogin.ts
@@ -1,20 +1,24 @@
 import { ApiClient } from '@transcenders/api-client';
 import { decodeToken, type AuthData, type LoginUser } from '@transcenders/contracts';
 import { useUser } from '../hooks/useUser';
+import { useAuth } from './useAuth';
 
 const useAuthLogin = () => {
   const { setUser } = useUser();
+  const { setTokens } = useAuth();
 
   async function login(username: string, password: string) {
     const loginInfo: LoginUser = { username, password };
-    const authData = await ApiClient.auth.login(loginInfo);
-    const payload = decodeToken(authData.accessToken);
+    const tokens = await ApiClient.auth.login(loginInfo);
+    setTokens(tokens);
+    const payload = decodeToken(tokens.accessToken);
 
     const user = await ApiClient.user.getUserById(payload.userId);
     setUser(user);
   }
 
   async function loginWithTokens(tokens: AuthData) {
+    setTokens(tokens);
     const { refreshToken } = tokens;
     const { userId } = decodeToken(refreshToken);
     const user = await ApiClient.user.getUserById(userId);

--- a/web/src/layout/Header.tsx
+++ b/web/src/layout/Header.tsx
@@ -1,16 +1,19 @@
 import { Cat, Home, LayoutDashboard, LogOut } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
-import { useUser } from '../hooks/useUser';
 import { usePlayers } from '../hooks/usePlayers';
+import { useUser } from '../hooks/useUser';
 
 import LanguageSwitch from '../components/LanguageSwitch';
+import { useAuth } from '../hooks/useAuth';
 
 const Header = () => {
   const { user, setUser } = useUser();
   const { resetAll } = usePlayers();
+  const { clearTokens } = useAuth();
 
   const handleLogout = () => {
+    clearTokens();
     resetAll();
     setUser(null);
   };

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
+import { AuthProvider } from './contexts/AuthContextProvider';
 import { PlayersProvider } from './contexts/PlayersContextProvider';
 import { UserProvider } from './contexts/UserContextProvider';
 import './i18n/i18n';
@@ -16,11 +17,13 @@ window.utils = Contracts;
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <BrowserRouter>
-      <UserProvider>
-        <PlayersProvider>
-          <App />
-        </PlayersProvider>
-      </UserProvider>
+      <AuthProvider>
+        <UserProvider>
+          <PlayersProvider>
+            <App />
+          </PlayersProvider>
+        </UserProvider>
+      </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>,
 );

--- a/web/src/utils/authTokens.ts
+++ b/web/src/utils/authTokens.ts
@@ -1,0 +1,25 @@
+import { AuthData } from '@transcenders/contracts';
+
+const ACCESS_KEY = 'accessToken';
+const REFRESH_KEY = 'refreshToken';
+
+export function saveTokens(tokens: AuthData) {
+  sessionStorage.setItem(ACCESS_KEY, tokens.accessToken);
+  localStorage.setItem(REFRESH_KEY, tokens.refreshToken);
+}
+
+export function saveAccessToken(accessToken: string) {
+  sessionStorage.setItem(ACCESS_KEY, accessToken);
+}
+
+export function getTokens(): Partial<AuthData> {
+  return {
+    accessToken: sessionStorage.getItem(ACCESS_KEY) ?? undefined,
+    refreshToken: localStorage.getItem(REFRESH_KEY) ?? undefined,
+  };
+}
+
+export function clearAllTokens() {
+  sessionStorage.removeItem(ACCESS_KEY);
+  localStorage.removeItem(REFRESH_KEY);
+}


### PR DESCRIPTION
Adds authentication system with automatic token management and user session restoration.

Creates centralized auth context that handles token storage, refresh logic, and global API client configuration. Introduces automatic login restoration on app startup that attempts to use existing tokens or refresh expired ones.

Enhances API client with global authorization header management that automatically includes bearer tokens in all requests.

worked on this for a few days while learning some react stuff. Decided to make it a seperate PR since its all frontend.
I know saving the tokens in local storage and session storage is not the safest, but backend has some protections agains token theft etc, so I think we are fine, I might make it with cookies later on, but will see

just needed this to get working to test some of the 2fa and google-auth things better, let me know if something looks off or bad.

so since this currently sets the user state, before any of the maincomponent rerouting happens, it will automatically go to deeper links also.

Also yeah it actually puts the access token into the header also, but nothing is really checking it yet, so 1 access token will last forever after login, in the future it will be rejected by Gateway whenever its expired, but that we can probably also handle in some nice hook or something.

so the links like http://localhost:5173/MatchPage and http://localhost:5173/TournamentPage will actually go to some blank nonexisting game with player1 and player2 as names etc, but we will probably need some game state system for that anyway right?

I guess it was the same with the old system without autologin also anyawy.