### PR TITLE
Delta time

### DIFF
--- a/packages/contracts/src/score.schemas.ts
+++ b/packages/contracts/src/score.schemas.ts
@@ -13,8 +13,8 @@ export const ScoreSchema = Type.Object({
   loser_score: Type.Number(),
   tournament_level: Type.Number(),
   game_duration: Type.Number(),
-  game_start: TimestampField,
-  game_end: TimestampField,
+  game_start: Type.Number(),
+  game_end: Type.Number(),
 });
 
 export const scoreArraySchema = Type.Array(ScoreSchema);

--- a/web/src/components/game/GameContainer.tsx
+++ b/web/src/components/game/GameContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useRef} from 'react';
 import PongCanvas from './canvas/PongCanvas';
 import { usePlayers } from '../../hooks/usePlayers';
 import { type GameResult } from './models/GameState';
@@ -161,7 +161,7 @@ const GameContainer: React.FC<GameContainerProps> = ({
       );
       
       try {
-        onGameComplete?.(gameResult, actualWinner.name);
+          onGameComplete?.(gameResult, actualWinner.name);
       } catch (error) {
         console.error('Failed to save game result:', error);
       } finally {
@@ -244,6 +244,7 @@ const GameContainer: React.FC<GameContainerProps> = ({
           };
           setGameState(finalState);
           onStatusChange?.(GameStatus.ENDED);
+          handleGameEnd(finalState);
           return;
         }
         newState = resetBall(stateAfterScoring);

--- a/web/src/components/game/GameContainer.tsx
+++ b/web/src/components/game/GameContainer.tsx
@@ -42,7 +42,6 @@ const GameContainer: React.FC<GameContainerProps> = ({
   player2,
 }) => {
   const [gameState, setGameState] = useState<GameState>(createInitialGameState(width, height));
-  const [keysPressed, setKeysPressed] = useState<Record<string, boolean>>({});
   const [gameStartTime, setGameStartTime] = useState<number | null>(null);
   const [isProcessingGameEnd, setIsProcessingGameEnd] = useState(false);
 
@@ -59,11 +58,6 @@ const GameContainer: React.FC<GameContainerProps> = ({
   useEffect(() => {
     gameStateRef.current = gameState;
   }, [gameState]);
-  
-  //update ref whenever keys change
-  useEffect (() => {
-    keysPressedRef.current = keysPressed;
-  }, [keysPressed]);
 
   // Get current players
   const getCurrentPlayers = () => {
@@ -148,21 +142,13 @@ const GameContainer: React.FC<GameContainerProps> = ({
       if (isProcessingGameEnd || !gameStartTime) return;
       
       const currentPlayers = getCurrentPlayers();
-      console.log('handleGameEnd - currentPlayers:', currentPlayers);
 
-      if (!currentPlayers) {
-        console.log('No current players found!');
-        return;
-      }
-      
+      if (!currentPlayers) return;
+
       setIsProcessingGameEnd(true);
-      
+
       const leftPlayerWon = finalGameState.leftScore > finalGameState.rightScore;
       const actualWinner = leftPlayerWon ? currentPlayers.player1 : currentPlayers.player2;
-      
-      console.log('leftPlayerWon:', leftPlayerWon);
-      console.log('actualWinner:', actualWinner);
-      console.log('winner name being sent:', actualWinner.name);
       
       const gameResult = createGameResult(
         currentPlayers.player1.id,
@@ -210,9 +196,6 @@ const GameContainer: React.FC<GameContainerProps> = ({
       let newState = { ...currentState };
 
       // Move paddles
-      if (gameStateRef.current.status !== GameStatus.RUNNING) {
-        return;
-      }
       if (keysPressedRef.current[Controls.leftPaddle.up.toLowerCase()]) {
         newState.leftPaddle.position.y = Math.max(
           0,
@@ -267,7 +250,7 @@ const GameContainer: React.FC<GameContainerProps> = ({
       } else {
         newState = stateAfterScoring;
       }
-      setGameState(newState);
+    setGameState(newState);
 
     // Continue animation loop regardless of game state (for smooth rendering)
     animationFrameRef.current = requestAnimationFrame(updateGame);
@@ -292,19 +275,15 @@ const GameContainer: React.FC<GameContainerProps> = ({
     const handleKeyDown = (e: KeyboardEvent) => {
       if (['ArrowUp', 'ArrowDown', 'w', 's'].includes(e.key)) {
         e.preventDefault();
+        keysPressedRef.current[e.key.toLowerCase()] = true;
       }
-
-      setKeysPressed((prevKeys) => ({
-        ...prevKeys,
-        [e.key.toLowerCase()]: true,
-      }));
     };
 
     const handleKeyUp = (e: KeyboardEvent) => {
-      setKeysPressed((prevKeys) => ({
-        ...prevKeys,
-        [e.key.toLowerCase()]: false,
-      }));
+      if (['ArrowUp', 'ArrowDown', 'w', 's'].includes(e.key)) {
+        keysPressedRef.current[e.key.toLowerCase()] = false;
+      }
+
     };
 
     window.addEventListener('keydown', handleKeyDown);

--- a/web/src/components/game/models/GameState.ts
+++ b/web/src/components/game/models/GameState.ts
@@ -71,9 +71,9 @@ export const Controls = {
 export const DEFAULT_GAME_SETTINGS = {
   paddleWidth: 40,
   paddleHeight: 100,
-  paddleSpeed: 300, //pixels per second
+  paddleSpeed: 450, //pixels per second
   ballRadius: 20,
-  ballInitialSpeed: 250, //pixels per second
+  ballInitialSpeed: 350, //pixels per second
   maxScore: 3,
 };
 

--- a/web/src/components/game/models/GameState.ts
+++ b/web/src/components/game/models/GameState.ts
@@ -71,9 +71,9 @@ export const Controls = {
 export const DEFAULT_GAME_SETTINGS = {
   paddleWidth: 40,
   paddleHeight: 100,
-  paddleSpeed: 10,
+  paddleSpeed: 300, //pixels per second
   ballRadius: 20,
-  ballInitialSpeed: 10,
+  ballInitialSpeed: 250, //pixels per second
   maxScore: 3,
 };
 

--- a/web/src/components/game/models/GameState.ts
+++ b/web/src/components/game/models/GameState.ts
@@ -71,9 +71,9 @@ export const Controls = {
 export const DEFAULT_GAME_SETTINGS = {
   paddleWidth: 40,
   paddleHeight: 100,
-  paddleSpeed: 450, //pixels per second
+  paddleSpeed: 550, //pixels per second
   ballRadius: 20,
-  ballInitialSpeed: 350, //pixels per second
+  ballInitialSpeed: 450, //pixels per second
   maxScore: 3,
 };
 

--- a/web/src/pages/MatchPage.tsx
+++ b/web/src/pages/MatchPage.tsx
@@ -80,8 +80,8 @@ function MatchPage() {
         loser_score: result.loser_score,
         tournament_level: result.tournament_level,
         game_duration: result.game_duration,
-        game_start: result.game_start.toString(),
-        game_end: result.game_end.toString(),
+        game_start: result.game_start,
+        game_end: result.game_end,
       };
 
       const response = await ApiClient.score.createScore(scoreData);

--- a/web/src/pages/TournamentPage.tsx
+++ b/web/src/pages/TournamentPage.tsx
@@ -266,8 +266,8 @@ function TournamentPage() {
           loser_score: result.loser_score,
           tournament_level: result.tournament_level,
           game_duration: result.game_duration,
-          game_start: result.game_start.toString(),
-          game_end: result.game_end.toString(),
+          game_start: result.game_start,
+          game_end: result.game_end,
         };
 
         const response = await ApiClient.score.createScore(scoreData);
@@ -282,7 +282,7 @@ function TournamentPage() {
   const getMatchTitle = () => {
     switch (tournamentState.currentMatch) {
       case 1:
-        return t('firstRound');
+        return t('first_round');
       case 2:
         return t('second_round');
       case 3:


### PR DESCRIPTION
Shifted game movement to use deltaTime instead of fps to get consistent speed across different computers. I'm getting a slight lag with paddle movements when the game is on the big screen, but suspect it's made to be worse because of my own pc and will follow up on the behavior when I get to a school computer. Also fixed the tournamentPage call from firstRound to first_round to match the translation files, and ignoring the React State warning 'Cannot update a component' during a tournament for now since the logic works.