### PR TITLE
Fix/return on no players

### DIFF
--- a/web/src/pages/MatchPage.tsx
+++ b/web/src/pages/MatchPage.tsx
@@ -28,6 +28,16 @@ function MatchPage() {
 
   const api = useApiClient();
 
+  // Redirect back to home if players not correctly set
+  useEffect(() => {
+    const allPlayersArray = [players[1], players[2]];
+    const validPlayers = allPlayersArray.filter((p) => p?.username);
+
+    if (validPlayers.length != 2) {
+      navigate('/', { replace: true });
+    }
+  }, [players, navigate]);
+
   const handleStartPause = useCallback(() => {
     if (gameStatus === GameStatus.WAITING || gameStatus === GameStatus.PAUSED) {
       setShouldStart(true);

--- a/web/src/pages/TournamentPage.tsx
+++ b/web/src/pages/TournamentPage.tsx
@@ -23,7 +23,6 @@ function TournamentPage() {
   const { players, setPlayer } = usePlayers();
   const navigate = useNavigate();
   const { t } = useTranslation();
-
   const api = useApiClient();
 
   const [tournamentState, setTournamentState] = useState<TournamentState>({
@@ -72,7 +71,7 @@ function TournamentPage() {
     const validPlayers = allPlayersArray.filter((p) => p?.username);
 
     if (validPlayers.length < 4) {
-      return;
+      navigate('/', { replace: true });
     }
 
     // Create shuffled tournament order
@@ -81,7 +80,7 @@ function TournamentPage() {
 
     setPlayer(1, shuffledPlayers[0]);
     setPlayer(2, shuffledPlayers[1]);
-  }, [players, setPlayer]);
+  }, [navigate, players, setPlayer]);
 
   // Get current players for rendering the page from the SHUFFLED tournament order
   const getCurrentMatchPlayers = () => {


### PR DESCRIPTION
Adds a navigation back to home in both matchPage and tournamentPage, if not enough valid players exist in the player context. Tested both pages and didn't find the implementation causing any issues. The pages do begin to render briefly before the navigation, so there is a small flicker. If @aneitenb knows of a quick fix to this, I'm all ears, but at this point I don't see this as something that necessarily needs fixing.