### PR TITLE
Fix/remove displayname frontend

### DIFF
--- a/web/src/components/FriendsList.tsx
+++ b/web/src/components/FriendsList.tsx
@@ -43,7 +43,7 @@ export default function FriendsList({ userId }: FriendsListProps) {
         ) : (
           friends.map((friend) => (
             <div key={friend.id} className="flex items-center justify-between text-[#fff] py-1">
-              <span>{friend.display_name ?? friend.username}</span>
+              <span>{friend.username}</span>
               <span
                 className={`w-3 h-3 rounded-full border border-white ${
                   friend.status === 'online' ? 'bg-[#ceff5d]' : 'bg-transparent'

--- a/web/src/pages/Profile.tsx
+++ b/web/src/pages/Profile.tsx
@@ -133,16 +133,6 @@ const Profile = () => {
           />
         </div>
         <div className="w-full max-w-md">
-          <label className="fascinate-label">{t('display_name')}</label>
-          <input
-            type="text"
-            value={displayName}
-            onChange={(e) => setDisplayName(e.target.value)}
-            className="input-field"
-            disabled={!isElevated}
-          />
-        </div>
-        <div className="w-full max-w-md">
           <label className="fascinate-label">{t('two_fac_auth')}</label>
           <TwoFactorSection />
         </div>


### PR DESCRIPTION
Removes all remaining visible use of the display_name user attribute:
- Deletes display name field from profile page
- Changes friend list to use username instead of display name

Back end is not affected.