### PR TITLE
Fix/game name scramble

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Transcenders Makefile
 
-all: local
+all: prod
 
 ################################################################################
 # SETUP
@@ -160,6 +160,9 @@ prod-stop:
 
 prod-clean:
 		$(PROD_DOCKER_COMPOSE) down --rmi all
+		
+prod-fcean:
+		$(PROD_DOCKER_COMPOSE) down -v --rmi all
 
 prod-logs:
 	@if [ -z "$(filter-out $@,$(MAKECMDGOALS))" ]; then \
@@ -177,7 +180,7 @@ prod-exec:
 		$(PROD_DOCKER_COMPOSE) exec -it $$SVC ash; \
 	fi
 
-.PHONY: prod prod-local prod-stop prod-logs prod-clean prod-clean-data
+.PHONY: prod prod-local prod-stop prod-logs prod-clean prod-clean-data prod-fcean
 
 ################################################################################
 # CLEAN

--- a/packages/api-client/src/api/ApiClient.ts
+++ b/packages/api-client/src/api/ApiClient.ts
@@ -38,7 +38,6 @@ export class ApiClient {
     const requestInit: RequestInit = {
       method,
       headers: hdrs,
-      //#TODO temporary disabled timeout for debugging
       // signal: AbortSignal.timeout(timeout),
     };
 

--- a/packages/contracts/src/score.schemas.ts
+++ b/packages/contracts/src/score.schemas.ts
@@ -15,7 +15,7 @@ export const scoreSchema = Type.Object({
   game_duration: Type.Number(),
   game_start: TimestampField,
   game_end: TimestampField,
-  created_at: Type.Optional(TimestampField),
+  created_at: TimestampField,
 });
 export const scoreArraySchema = Type.Array(scoreSchema);
 export type Score = Static<typeof scoreSchema>;

--- a/packages/contracts/src/utils/BooleanResultHelper.ts
+++ b/packages/contracts/src/utils/BooleanResultHelper.ts
@@ -1,6 +1,4 @@
 import { BooleanOperationResult } from '../user.schemas.js';
-
-// #TODO boolean results are a bit weird, maybe we throw ServiceError on failures instead, and get proper messages with localeKey
 export class BooleanResultHelper {
   static success(message: string): BooleanOperationResult {
     return {

--- a/scripts/artifact-cleanup.sh
+++ b/scripts/artifact-cleanup.sh
@@ -22,6 +22,7 @@ find "$WORKSPACE_DIR" -type d -name "node_modules" -prune -o -name "*.tsbuildinf
 # Remove web/.vite directory
 echo "-- Removing web/.vite"
 rm -rf "$WORKSPACE_DIR/web/.vite"
+rm -rf "$WORKSPACE_DIR/database/"
 # Remove node_modules/.vite-temp directory
 echo "-- Removing node_modules/.vite-temp"
 rm -rf "$WORKSPACE_DIR/node_modules/.vite-temp"

--- a/services/auth-service/src/routes/twoFactor.routes.ts
+++ b/services/auth-service/src/routes/twoFactor.routes.ts
@@ -56,7 +56,6 @@ export async function registerTwoFactorRoutes(app: FastifyInstance) {
   app.post(
     TWO_FACTOR_ROUTES.REQUEST_LOGIN,
     {
-      // TODO maybe change to owner() again when handling the email sending differently from frontend
       preHandler: app.authenticate.internal(),
       schema: {
         description: 'Request a login-time 2FA challenge',
@@ -71,7 +70,6 @@ export async function registerTwoFactorRoutes(app: FastifyInstance) {
   app.post(
     TWO_FACTOR_ROUTES.LOGIN,
     {
-      // TODO maybe change to owner() again when handling the email sending differently from frontend
       preHandler: app.authenticate.internal(),
       schema: {
         description: 'Verify 2FA login code',

--- a/services/auth-service/src/services/auth.service.ts
+++ b/services/auth-service/src/services/auth.service.ts
@@ -132,7 +132,6 @@ export class AuthService {
     return result.changes ?? 0;
   }
 
-  // #TODO maybe a seperate try catch to delete user if something actually goes wrong, then rethrow to close up the transaction
   static async register(registration: RegisterUser): Promise<ServiceResult<User>> {
     const userCreationInfo: CreateUserRequest = {
       username: registration.username,
@@ -485,7 +484,6 @@ export class AuthService {
     );
   }
 
-  // #TODO handle failed user creations, by syncing user and auth DB entries
   static async googleLogin(
     code: string,
     deviceInfo: DeviceInfo,

--- a/services/score-service/src/db/init.sql
+++ b/services/score-service/src/db/init.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS scores (
   game_duration INTEGER NOT NULL,
   game_start TIMESTAMP NOT NULL,
   game_end TIMESTAMP NOT NULL,
-  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   
   CHECK (winner_id != loser_id OR (winner_id = 0 AND loser_id = 0)),
   CHECK (winner_score > 0),

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <link
-      rel="preload"
       href="https://fonts.gstatic.com/s/fascinate/v15/zYX6KVFJDiQALw1PeKnS9k-T.woff2"
       as="font"
       type="font/woff2"

--- a/web/src/components/PlayerLoginForm.tsx
+++ b/web/src/components/PlayerLoginForm.tsx
@@ -10,9 +10,10 @@ import type { Player } from '../types/types';
 interface Props {
   playerNumber: number;
   player?: Player;
+  displayLabel?: string;
 }
 
-const PlayerLoginForm = ({ playerNumber, player }: Props) => {
+const PlayerLoginForm = ({ playerNumber, player, displayLabel }: Props) => {
   const { players, setPlayer, resetPlayer } = usePlayers();
   const { login } = useVerifyLogin();
   const { t } = useTranslation();
@@ -87,7 +88,7 @@ const PlayerLoginForm = ({ playerNumber, player }: Props) => {
     return (
       <>
         <h2 className="fascinate-label mb-[clamp(7px,0.47vw,12px)]">
-          {t('player')} {playerNumber}
+          {displayLabel || `${t('player')} ${playerNumber}`}
         </h2>
         <div className="flex flex-col gap-[clamp(5px,0.31vw,8px)] items-center">
           <button
@@ -112,7 +113,7 @@ const PlayerLoginForm = ({ playerNumber, player }: Props) => {
     return (
       <>
         <h2 className="fascinate-label">
-          {t('player')} {playerNumber}
+          {displayLabel || `${t('player')} ${playerNumber}`}
         </h2>
         <p className="border-b-2 border-white text-start text-fluid-sm">{player.username}</p>
         <div className="flex justify-between mt-[clamp(5px,0.61vh,8px)] p-[clamp(5px,0.31vw,8px)]">
@@ -129,7 +130,7 @@ const PlayerLoginForm = ({ playerNumber, player }: Props) => {
   return (
     <>
       <h2 className="fascinate-label">
-        {t('player')} {playerNumber}
+        {displayLabel || `${t('player')} ${playerNumber}`}
       </h2>
       <input
         type="text"

--- a/web/src/components/UserSearch.tsx
+++ b/web/src/components/UserSearch.tsx
@@ -35,12 +35,16 @@ export default function UserSearch({
             className="p-[clamp(3px,0.16vw,4px)] h-[clamp(26px,2.76vh,36px)] aspect-square rounded-full bg-white/10 flex items-center justify-center relative group"
           >
             <ChevronRight className="h-[clamp(11.5px,1.5vh,20px)] aspect-square" />
+            <span className="absolute hidden button-label bottom-full left-2/3">{t('search')}</span>
           </button>
           <button
             onClick={handleGoBack}
             className="p-[clamp(5px,0.31vw,8px)] h-[clamp(26px,2.76vh,36px)] aspect-square rounded-full bg-white/10 flex items-center justify-center relative group"
           >
             <Cat className="h-[clamp(11.5px,1.5vh,20px)] aspect-square" />
+            <span className="absolute hidden button-label bottom-full left-2/3">
+              {t('your_page')}
+            </span>
           </button>
         </div>
 

--- a/web/src/components/game/GameContainer.tsx
+++ b/web/src/components/game/GameContainer.tsx
@@ -118,10 +118,10 @@ const GameContainer: React.FC<GameContainerProps> = ({
       if (response?.match_id) {
         return response.match_id;
       } else {
-          return null;
+        return null;
       }
     } catch (error) {
-        return null;
+      return null;
     }
   };
 
@@ -263,12 +263,12 @@ const GameContainer: React.FC<GameContainerProps> = ({
       );
     }
 
-    const previousBallX = newState.ball.position.x; //ADDED 
-    
+    const previousBallX = newState.ball.position.x; //ADDED
+
     // Move ball
     newState.ball.position.x += newState.ball.velocity.dx * deltaTime;
     newState.ball.position.y += newState.ball.velocity.dy * deltaTime;
-    
+
     //check score
     const { newState: stateAfterScoring, scored } = checkScore(newState, previousBallX);
 
@@ -287,7 +287,7 @@ const GameContainer: React.FC<GameContainerProps> = ({
         handleGameEnd(finalState);
         return;
       }
-       const resetState = resetBall(stateAfterScoring);
+      const resetState = resetBall(stateAfterScoring);
       setGameState(resetState);
       animationFrameRef.current = requestAnimationFrame(updateGame);
       return;
@@ -296,7 +296,7 @@ const GameContainer: React.FC<GameContainerProps> = ({
     newState = stateAfterScoring;
     // Check wall collisions
     newState = checkWallCollision(newState);
-    
+
     // Check paddle collisions
     newState = handlePaddleCollisions(newState);
     setGameState(newState);

--- a/web/src/components/game/canvas/PongCanvas.tsx
+++ b/web/src/components/game/canvas/PongCanvas.tsx
@@ -53,7 +53,6 @@ const PongCanvas: React.FC<PongCanvasProps> = ({ gameState }) => {
         });
         setImagesLoaded(true);
       } catch (error) {
-        console.error('Failed to load game images:', error);
       }
     };
     loadImages();

--- a/web/src/components/game/utils/CollisionDetection.ts
+++ b/web/src/components/game/utils/CollisionDetection.ts
@@ -103,22 +103,33 @@ export const handlePaddleCollisions = (gameState: GameState): GameState => {
   return newState;
 };
 
-// Check if a point is scored
-export const checkScore = (gameState: GameState): { newState: GameState; scored: boolean } => {
+export const checkScore = (
+  gameState: GameState, 
+  previousBallX: number
+): { newState: GameState; scored: boolean } => {
   const { ball, canvasWidth, leftScore, rightScore } = gameState;
   const newState = { ...gameState };
   let scored = false;
 
-  // if ball passes left edge, right player scores
-  if (ball.position.x - ball.radius <= 0) {
+  const currentBallX = ball.position.x;
+  const ballRadius = ball.radius;
+
+  // check if ball crossed left boundary during this frame
+  const ballLeftEdge = currentBallX - ballRadius;
+  const ballRightEdge = currentBallX + ballRadius;
+  const prevBallLeftEdge = previousBallX - ballRadius;
+  const prevBallRightEdge = previousBallX + ballRadius;
+
+  // Left goal: check if ball crossed from positive to negative (or was already past)
+  if ((prevBallLeftEdge > 0 && ballLeftEdge <= 0) || ballLeftEdge <= 0) {
     newState.rightScore = rightScore + 1;
     scored = true;
   }
-
-  // if ball passes the right edge, left player scores
-  if (ball.position.x + ball.radius >= canvasWidth) {
+  // Right goal: check if ball crossed from left side to past right boundary
+  else if ((prevBallRightEdge < canvasWidth && ballRightEdge >= canvasWidth) || ballRightEdge >= canvasWidth) {
     newState.leftScore = leftScore + 1;
     scored = true;
   }
+
   return { newState, scored };
 };

--- a/web/src/contexts/PlayersContextProvider.tsx
+++ b/web/src/contexts/PlayersContextProvider.tsx
@@ -4,10 +4,31 @@ import { PlayersContext } from './PlayersContext';
 import type { PlayersMap } from './PlayersContext';
 import type { Player } from '../types/types';
 
+const emptyPlayer: Player = {
+  id: undefined,
+  username: '',
+  avatar: '',
+  mode: null,
+  ready: false,
+};
+
+const initialPlayers: PlayersMap = {
+  1: { ...emptyPlayer }, // match player 1
+  2: { ...emptyPlayer }, // match player 2
+  3: { ...emptyPlayer }, // tournament player 1
+  4: { ...emptyPlayer }, // tournament player 2
+  5: { ...emptyPlayer }, // tournament player 3
+  6: { ...emptyPlayer }, // tournament player 4
+};
+
 export function PlayersProvider({ children }: { children: ReactNode }) {
   const [players, setPlayers] = useState<PlayersMap>({});
 
   const setPlayer = useCallback((num: number, data: Player) => {
+    if (num < 1 || num > 6) {
+      console.warn(`Invalid player slot: ${num}. Only slots 1-6 are allowed.`);
+      return;
+    }
     setPlayers((prev) => ({
       ...prev,
       [num]: {
@@ -18,15 +39,18 @@ export function PlayersProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const resetPlayer = useCallback((num: number) => {
-    setPlayers((prev) => {
-      const newPlayers = { ...prev };
-      delete newPlayers[num];
-      return newPlayers;
-    });
+    if (num < 1 || num > 6) {
+      console.warn(`Invalid player slot: ${num}. Only slots 1-6 are allowed.`);
+      return;
+    }
+    setPlayers((prev) => ({
+      ...prev,
+      [num]: { ...emptyPlayer },
+    }));
   }, []);
 
   const resetAll = useCallback(() => {
-    setPlayers({});
+    setPlayers({...initialPlayers});
   }, []);
 
   const contextValue = useMemo(

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,6 +1,5 @@
 import { ApiClient } from '@transcenders/api-client';
 import * as Contracts from '@transcenders/contracts';
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
@@ -15,7 +14,6 @@ window.api = ApiClient;
 window.utils = Contracts;
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
     <BrowserRouter>
       <AuthProvider>
         <UserProvider>
@@ -24,6 +22,5 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
           </PlayersProvider>
         </UserProvider>
       </AuthProvider>
-    </BrowserRouter>
-  </React.StrictMode>,
+    </BrowserRouter>,
 );

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -9,18 +9,14 @@ import { UserProvider } from './contexts/UserContextProvider';
 import './i18n/i18n';
 import './styles/index.css';
 
-//#TODO DEV only, remove for prod or change later
-window.api = ApiClient;
-window.utils = Contracts;
-
 ReactDOM.createRoot(document.getElementById('root')!).render(
-    <BrowserRouter>
-      <AuthProvider>
-        <UserProvider>
-          <PlayersProvider>
-            <App />
-          </PlayersProvider>
-        </UserProvider>
-      </AuthProvider>
-    </BrowserRouter>,
+  <BrowserRouter>
+    <AuthProvider>
+      <UserProvider>
+        <PlayersProvider>
+          <App />
+        </PlayersProvider>
+      </UserProvider>
+    </AuthProvider>
+  </BrowserRouter>,
 );

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -121,10 +121,18 @@ const Home = () => {
                 />
               </div>
               <div className="w-full max-w-[384px] h-[174px] p-4">
-                <PlayerLoginForm playerNumber={3} player={players[5]} />
+                <PlayerLoginForm
+                  playerNumber={5}
+                  player={players[5]}
+                  displayLabel={`${t('player')} 3`}
+                />
               </div>
               <div className="w-full max-w-[384px] h-[174px] p-4">
-                <PlayerLoginForm playerNumber={4} player={players[6]} />
+                <PlayerLoginForm
+                  playerNumber={6}
+                  player={players[6]}
+                  displayLabel={`${t('player')} 4`}
+                />
               </div>
             </div>
           )}

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -22,7 +22,7 @@ const Home = () => {
         mode: 'login',
         ready: true,
       });
-      
+
       if (gameMode === 'tournament') {
         setPlayer(3, {
           id: user?.id,
@@ -98,15 +98,33 @@ const Home = () => {
                 </p>
                 <p className="flex justify-end text-lg mt-2 p-2">✓</p>
               </div>
-              
+
               <div className="w-full max-w-[384px] h-[174px] p-4">
-                <PlayerLoginForm playerNumber={4} player={players[4]} displayLabel={`${t('player')} 2`}/>
+                <PlayerLoginForm
+                  playerNumber={4}
+                  player={players[4]}
+                  displayLabel={`${t('player')} 2`}
+                />
               </div>
               <div className="w-full max-w-[384px] h-[174px] p-4">
-                <PlayerLoginForm playerNumber={5} player={players[5]} displayLabel={`${t('player')} 3`}/>
+                <PlayerLoginForm
+                  playerNumber={5}
+                  player={players[5]}
+                  displayLabel={`${t('player')} 3`}
+                />
               </div>
               <div className="w-full max-w-[384px] h-[174px] p-4">
-                <PlayerLoginForm playerNumber={6} player={players[6]} displayLabel={`${t('player')} 4`}/>
+                <PlayerLoginForm
+                  playerNumber={6}
+                  player={players[6]}
+                  displayLabel={`${t('player')} 4`}
+                />
+              </div>
+              <div className="w-full max-w-[384px] h-[174px] p-4">
+                <PlayerLoginForm playerNumber={5} player={players[5]} />
+              </div>
+              <div className="w-full max-w-[384px] h-[174px] p-4">
+                <PlayerLoginForm playerNumber={6} player={players[6]} />
               </div>
             </div>
           )}

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -120,20 +120,6 @@ const Home = () => {
                   displayLabel={`${t('player')} 4`}
                 />
               </div>
-              <div className="w-full max-w-[384px] h-[174px] p-4">
-                <PlayerLoginForm
-                  playerNumber={5}
-                  player={players[5]}
-                  displayLabel={`${t('player')} 3`}
-                />
-              </div>
-              <div className="w-full max-w-[384px] h-[174px] p-4">
-                <PlayerLoginForm
-                  playerNumber={6}
-                  player={players[6]}
-                  displayLabel={`${t('player')} 4`}
-                />
-              </div>
             </div>
           )}
           <div className="absolute bottom-[130px]">

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { useTranslation } from 'react-i18next';
@@ -22,8 +22,8 @@ const Home = () => {
         mode: 'login',
         ready: true,
       });
-
-      if (gameMode === 'tournament') {
+      
+      if (gameMode === 'tournament'){
         setPlayer(3, {
           id: user?.id,
           username: user?.username,
@@ -65,10 +65,7 @@ const Home = () => {
       {gameMode === 'match' && (
         <div className="box-section bg-[#6e5d41]/10 justify-center">
           <h1 className="text-fluid-4xl font-fascinate uppercase">{t('one_v_one')}</h1>
-          <button
-            onClick={() => setGameMode('none')}
-            className="mb-[clamp(40px,3.7vw,90px)]"
-          >
+          <button onClick={() => setGameMode('none')} className="mb-[clamp(40px,3.7vw,90px)]">
             {t('switch_game_mode')}
           </button>
           <div className="flex flex-col sm:flex-row justify-center sm:gap-10">
@@ -81,62 +78,12 @@ const Home = () => {
                 ✓
               </p>
             </div>
-            <div className="w-full max-w-[384px] h-[174px] p-4">
-                <PlayerLoginForm playerNumber={2} player={players[2]} />
-              </div>
-          )}
-
-          {gameMode === 'tournament' && (
-            <div
-              ref={playerFormRef}
-              className="box-section xl:bg-[#6e5d41]/10 justify-center xl:max-w-[790px]"
-            >
-              <div className="w-full max-w-[384px] h-[174px] p-4">
-                <h2 className="fascinate-label mb-3">{t('player')} 1</h2>
-                <p className="border-b-2 border-white text-lg flex justify-between">
-                  {user?.username}
-                </p>
-                <p className="flex justify-end text-lg mt-2 p-2">✓</p>
-              </div>
-
-              <div className="w-full max-w-[384px] h-[174px] p-4">
-                <PlayerLoginForm
-                  playerNumber={4}
-                  player={players[4]}
-                  displayLabel={`${t('player')} 2`}
-                />
-              </div>
-              <div className="w-full max-w-[384px] h-[174px] p-4">
-                <PlayerLoginForm
-                  playerNumber={5}
-                  player={players[5]}
-                  displayLabel={`${t('player')} 3`}
-                />
-              </div>
-              <div className="w-full max-w-[384px] h-[174px] p-4">
-                <PlayerLoginForm
-                  playerNumber={6}
-                  player={players[6]}
-                  displayLabel={`${t('player')} 4`}
-                />
-              </div>
+            <div className="w-[clamp(250px,15.6vw,280px)] h-[clamp(130px,13.35vh,174px)] p-[clamp(9px,0.63vw,16px)] text-center">
+              <PlayerLoginForm playerNumber={2} player={players[2]} />
             </div>
-          )}
-          <div className="absolute bottom-[130px]">
-            {gameMode === 'tournament' &&
-              players[3]?.ready &&
-              players[4]?.ready &&
-              players[5]?.ready &&
-              players[6]?.ready && (
-                <Link
-                  to="/TournamentPage"
-                  className="rounded-button bg-[#6e5d41]/15 font-fascinate uppercase"
-                >
-                  start
-                </Link>
-              )}
-
-            {gameMode === 'match' && players[2]?.ready && (
+          </div>
+          <div className="flex justify-center h-[36px]">
+            {players[2]?.ready && (
               <Link
                 to="/MatchPage"
                 className="font-fascinate uppercase text-fluid-xl text-white hover:text-[#786647] mt-[clamp(37px,2.8vw,72px)]"
@@ -166,20 +113,20 @@ const Home = () => {
                 </p>
               </div>
               <div className="w-[clamp(250px,15.6vw,280px)] h-[clamp(130px,13.35vh,174px)] p-[clamp(9px,0.63vw,16px)] text-center">
-                <PlayerLoginForm playerNumber={2} player={players[2]} />
+                <PlayerLoginForm playerNumber={4} player={players[4]} displayLabel={`${t('player')} 2`}/>
               </div>
             </div>
             <div className="flex flex-col sm:flex-row justify-center sm:gap-10">
               <div className="w-[clamp(250px,15.6vw,280px)] h-[clamp(130px,13.35vh,174px)] p-[clamp(9px,0.63vw,16px)] text-center">
-                <PlayerLoginForm playerNumber={3} player={players[3]} />
+                <PlayerLoginForm playerNumber={5} player={players[5]} displayLabel={`${t('player')} 3`}/>
               </div>
               <div className="w-[clamp(250px,15.6vw,280px)] h-[clamp(130px,13.35vh,174px)] p-[clamp(9px,0.63vw,16px)] text-center">
-                <PlayerLoginForm playerNumber={4} player={players[4]} />
+                <PlayerLoginForm playerNumber={6} player={players[6]} displayLabel={`${t('player')} 4`}/>
               </div>
             </div>
           </div>
           <div className="flex justify-center h-[36px]">
-            {players[2]?.ready && players[3]?.ready && players[4]?.ready && (
+            {players[4]?.ready && players[5]?.ready && players[6]?.ready && (
               <Link
                 to="/TournamentPage"
                 className="font-fascinate uppercase text-fluid-xl text-white hover:text-[#786647] mt-[clamp(37px,2.8vw,72px)]"

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -98,14 +98,15 @@ const Home = () => {
                 </p>
                 <p className="flex justify-end text-lg mt-2 p-2">✓</p>
               </div>
+              
               <div className="w-full max-w-[384px] h-[174px] p-4">
-                <PlayerLoginForm playerNumber={2} player={players[4]} />
+                <PlayerLoginForm playerNumber={4} player={players[4]} displayLabel={`${t('player')} 2`}/>
               </div>
               <div className="w-full max-w-[384px] h-[174px] p-4">
-                <PlayerLoginForm playerNumber={3} player={players[5]} />
+                <PlayerLoginForm playerNumber={5} player={players[5]} displayLabel={`${t('player')} 3`}/>
               </div>
               <div className="w-full max-w-[384px] h-[174px] p-4">
-                <PlayerLoginForm playerNumber={4} player={players[6]} />
+                <PlayerLoginForm playerNumber={6} player={players[6]} displayLabel={`${t('player')} 4`}/>
               </div>
             </div>
           )}

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -99,13 +99,13 @@ const Home = () => {
                 <p className="flex justify-end text-lg mt-2 p-2">✓</p>
               </div>
               <div className="w-full max-w-[384px] h-[174px] p-4">
-                <PlayerLoginForm playerNumber={4} player={players[4]} />
+                <PlayerLoginForm playerNumber={2} player={players[4]} />
               </div>
               <div className="w-full max-w-[384px] h-[174px] p-4">
-                <PlayerLoginForm playerNumber={5} player={players[5]} />
+                <PlayerLoginForm playerNumber={3} player={players[5]} />
               </div>
               <div className="w-full max-w-[384px] h-[174px] p-4">
-                <PlayerLoginForm playerNumber={6} player={players[6]} />
+                <PlayerLoginForm playerNumber={4} player={players[6]} />
               </div>
             </div>
           )}

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -22,8 +22,18 @@ const Home = () => {
         mode: 'login',
         ready: true,
       });
+      
+      if (gameMode === 'tournament') {
+        setPlayer(3, {
+          id: user?.id,
+          username: user?.username,
+          avatar: user?.avatar,
+          mode: 'login',
+          ready: true,
+        });
+      }
     }
-  }, [user?.id, user?.username, user?.avatar, setPlayer]);
+  }, [user?.id, user?.username, user?.avatar, setPlayer, gameMode]);
 
   return (
     <div className="box">
@@ -71,12 +81,49 @@ const Home = () => {
                 ✓
               </p>
             </div>
-            <div className="w-[clamp(250px,15.6vw,280px)] h-[clamp(130px,13.35vh,174px)] p-[clamp(9px,0.63vw,16px)] text-center">
-              <PlayerLoginForm playerNumber={2} player={players[2]} />
+            <div className="w-full max-w-[384px] h-[174px] p-4">
+                <PlayerLoginForm playerNumber={2} player={players[2]} />
+              </div>
+          )}
+
+          {gameMode === 'tournament' && (
+            <div
+              ref={playerFormRef}
+              className="box-section xl:bg-[#6e5d41]/10 justify-center xl:max-w-[790px]"
+            >
+              <div className="w-full max-w-[384px] h-[174px] p-4">
+                <h2 className="fascinate-label mb-3">{t('player')} 1</h2>
+                <p className="border-b-2 border-white text-lg flex justify-between">
+                  {user?.username}
+                </p>
+                <p className="flex justify-end text-lg mt-2 p-2">✓</p>
+              </div>
+              <div className="w-full max-w-[384px] h-[174px] p-4">
+                <PlayerLoginForm playerNumber={4} player={players[4]} />
+              </div>
+              <div className="w-full max-w-[384px] h-[174px] p-4">
+                <PlayerLoginForm playerNumber={5} player={players[5]} />
+              </div>
+              <div className="w-full max-w-[384px] h-[174px] p-4">
+                <PlayerLoginForm playerNumber={6} player={players[6]} />
+              </div>
             </div>
-          </div>
-          <div className="flex justify-center h-[36px]">
-            {players[2]?.ready && (
+          )}
+          <div className="absolute bottom-[130px]">
+            {gameMode === 'tournament' &&
+              players[3]?.ready &&
+              players[4]?.ready &&
+              players[5]?.ready &&
+              players[6]?.ready && (
+                <Link
+                  to="/TournamentPage"
+                  className="rounded-button bg-[#6e5d41]/15 font-fascinate uppercase"
+                >
+                  start
+                </Link>
+              )}
+
+            {gameMode === 'match' && players[2]?.ready && (
               <Link
                 to="/MatchPage"
                 className="font-fascinate uppercase text-fluid-xl text-white hover:text-[#786647] mt-[clamp(37px,2.8vw,72px)]"

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -121,10 +121,10 @@ const Home = () => {
                 />
               </div>
               <div className="w-full max-w-[384px] h-[174px] p-4">
-                <PlayerLoginForm playerNumber={5} player={players[5]} />
+                <PlayerLoginForm playerNumber={3} player={players[5]} />
               </div>
               <div className="w-full max-w-[384px] h-[174px] p-4">
-                <PlayerLoginForm playerNumber={6} player={players[6]} />
+                <PlayerLoginForm playerNumber={4} player={players[6]} />
               </div>
             </div>
           )}

--- a/web/src/pages/MatchPage.tsx
+++ b/web/src/pages/MatchPage.tsx
@@ -104,9 +104,7 @@ function MatchPage() {
       };
 
       const response = await api(() => ApiClient.score.createScore(scoreData));
-      console.log('SUCCESS: sent score data to backend', response);
     } catch (error) {
-      console.error('Failed to send score data:', error);
     } finally {
       setIsProcessingGameEnd(false);
     }

--- a/web/src/pages/MatchPage.tsx
+++ b/web/src/pages/MatchPage.tsx
@@ -186,7 +186,7 @@ function MatchPage() {
 
           {/* Game Canvas */}
           <div className="flex justify-center">
-            <div className="relative w-full max-w-[1000px] aspect-[5/4] overflow-hidden">
+            <div className="relative w-full max-w-[min(70vw,1000px)] max-h-[min(40vh,800px)] aspect-[5/4] overflow-hidden">
               <GameContainer
                 key={gameKey}
                 width={1000}

--- a/web/src/pages/TournamentPage.tsx
+++ b/web/src/pages/TournamentPage.tsx
@@ -81,7 +81,7 @@ function TournamentPage() {
     setPlayer(1, shuffledPlayers[0]);
     setPlayer(2, shuffledPlayers[1]);
   }, [navigate, players, setPlayer, resetPlayer]);
-  
+
   //cleanup
   useEffect(() => {
     return () => {

--- a/web/src/pages/TournamentPage.tsx
+++ b/web/src/pages/TournamentPage.tsx
@@ -206,7 +206,7 @@ function TournamentPage() {
     setWinner(winnerName ?? 'Unknown Player'); //sets winner for rendering after match
     const newWinners = [...winners, winner];
     const newResults = [...gameResults, updatedResult];
-    
+
     // If final match, send scores immediately and mark complete
     if (currentMatch === 3) {
       setTournamentState((prev) => ({
@@ -217,7 +217,7 @@ function TournamentPage() {
         gameResults: newResults,
         isComplete: true,
       }));
-      
+
       // Send all results immediately
       await sendTournamentResults(newResults);
     } else {
@@ -296,12 +296,7 @@ function TournamentPage() {
 
         return api(() => ApiClient.score.createScore(scoreData));
       });
-
-      const responses = await Promise.all(promises);
-      console.log('All tournament results saved successfully', responses);
-    } catch (error) {
-      console.error('Failed to send tournament results:', error);
-    }
+    } catch (error) {}
   };
 
   const getMatchTitle = () => {

--- a/web/src/pages/TournamentPage.tsx
+++ b/web/src/pages/TournamentPage.tsx
@@ -394,7 +394,7 @@ function TournamentPage() {
 
           {/* Game Canvas */}
           <div className="flex justify-center">
-            <div className="relative w-full max-w-[1000px] aspect-[5/4] overflow-hidden">
+            <div className="relative w-full max-w-[min(70vw,1000px)] max-h-[min(40vh,800px)] aspect-[5/4] overflow-hidden">
               <GameContainer
                 key={tournamentState.gameKey}
                 width={1000}

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -5,16 +5,6 @@
 
 @theme {
   --font-fascinate: 'Fascinate', 'system-ui';
-  --font-size-xs: clamp(0.65rem, 0.7vw, 0.75rem);   /* 10.5px – 12px */
-  --font-size-sm: clamp(0.75rem, 0.8vw, 0.875rem);  /* 12px – 14px */
-  --font-size-base: clamp(0.875rem, 0.9vw, 1rem);   /* 14px – 16px */
-  --font-size-lg: clamp(1rem, 1vw, 1.125rem);       /* 16px – 18px */
-  --font-size-xl: clamp(1.125rem, 1.2vw, 1.25rem);  /* 18px – 20px */
-  --font-size-2xl: clamp(1.25rem, 1.6vw, 1.5rem);   /* 20px – 24px */
-  --font-size-3xl: clamp(1.5rem, 2vw, 1.875rem);    /* 24px – 30px */
-  --font-size-4xl: clamp(1.875rem, 2.5vw, 2.25rem); /* 30px – 36px */
-  --font-size-5xl: clamp(2.5rem, 3vw, 3rem);        /* 40px – 48px */
-  --font-size-6xl: clamp(2.5rem,2.8vw,4.5rem);       /* 40px – 72px */
 }
 
 @layer base {
@@ -105,45 +95,44 @@
 }
 
 @utility text-fluid-xs {
-  font-size: clamp(0.75rem, 0.6vw + 0.3vh, 1rem); /* 12px → 16px */
+  font-size: clamp(0.75rem, 0.6vw + 0.3vh, 1rem);
 }
 
 @utility text-fluid-sm {
-  font-size: clamp(0.875rem, 0.7vw + 0.35vh, 1.125rem); /* 14px → 18px */
+  font-size: clamp(0.875rem, 0.7vw + 0.35vh, 1.125rem);
 }
 
 @utility text-fluid-base {
-  font-size: clamp(1rem, 0.8vw + 0.4vh, 1.25rem); /* 16px → 20px */
+  font-size: clamp(1rem, 0.8vw + 0.4vh, 1.25rem);
 }
 
 @utility text-fluid-lg {
-  font-size: clamp(1.125rem, 0.9vw + 0.45vh, 1.5rem); /* 18px → 24px */
+  font-size: clamp(1.125rem, 0.9vw + 0.45vh, 1.5rem);
 }
 
 @utility text-fluid-xl {
-  font-size: clamp(1.25rem, 1vw + 0.5vh, 1.75rem); /* 20px → 28px */
+  font-size: clamp(1.25rem, 1vw + 0.5vh, 1.75rem);
 }
 
 @utility text-fluid-2xl {
-  font-size: clamp(1.5rem, 1.2vw + 0.6vh, 2rem); /* 24px → 32px */
+  font-size: clamp(1.5rem, 1.2vw + 0.6vh, 2rem);
 }
 
 @utility text-fluid-3xl {
-  font-size: clamp(1.875rem, 1.4vw + 0.7vh, 2.5rem); /* 30px → 40px */
+  font-size: clamp(1.875rem, 1.4vw + 0.7vh, 2.5rem);
 }
 
 @utility text-fluid-4xl {
-  font-size: clamp(2.25rem, 1.6vw + 0.8vh, 3rem); /* 36px → 48px */
+  font-size: clamp(2.25rem, 1.6vw + 0.8vh, 3rem);
 }
 
 @utility text-fluid-5xl {
-  font-size: clamp(3rem, 2vw + 1vh, 3.75rem); /* 48px → 60px */
+  font-size: clamp(3rem, 2vw + 1vh, 3.75rem);
 }
 
 @utility text-fluid-6xl {
-  font-size: clamp(3.75rem, 2.5vw + 1.2vh, 4.5rem); /* 60px → 72px */
+  font-size: clamp(3.75rem, 2.5vw + 1.2vh, 4.5rem);
 }
-
 
 @utility tsc-error-message {
   @apply text-[#786647af] text-fluid-xs;


### PR DESCRIPTION
Fixed tournament name scrambling bug by separating player data into dedicated slots (1-2 for matches, 3-4-5-6 for tournament) and added proper cleanup if users leave a tournament or match mid-way.
Also changed the game canvas to adjust to the size of the screen so we don't have to scroll to see the full playing field.
Finally, changed some of PlayerLoginForm to accept a displayLabel so I can display the tournament signup list with players 2, 3, and 4 (now that internally they are actually 4,5,6)